### PR TITLE
fix error when function name contain \r\n

### DIFF
--- a/lib/jscover.js
+++ b/lib/jscover.js
@@ -87,7 +87,13 @@ function getJsFunctionInitialization(fileName, functionNames) {
             num: i,
             line: functionNames[i][1],
             column: functionNames[i][2],
-            functionName: functionNames[i][0].replace(/'/g, "\\'")
+            functionName: functionNames[i][0].replace(/['\r\n]/g, function(all){
+                return '\\'+ {
+                    "'": "'",
+                    '\r': 'r',
+                    '\n': 'n'
+                }[all];
+            })
         }));
     }
     sb.push('}');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-jscover",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "description": "node version of JSCover",
   "author": "yiminghe <yiminghe@gmail.com>",
   "directories": {


### PR DESCRIPTION
fix error when function name contain \r\n
